### PR TITLE
Feat/#1-User 및 Team 페이지, 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Layout from './app/Layout'
 import HomePage from './pages/Home'
 import MatchesPage from './pages/Matches'
 import TeamsPage from './pages/Teams'
+import TeamDetailPage from './pages/TeamDetail'
 import LoginPage from './pages/Login'
 import PrivateRoute from './app/PrivateRoute'
 import SignupPage from './pages/Signup'
@@ -18,6 +19,7 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/matches" element={<PrivateRoute><MatchesPage /></PrivateRoute>} />
         <Route path="/teams" element={<PrivateRoute><TeamsPage /></PrivateRoute>} />
+        <Route path="/teams/:teamId" element={<PrivateRoute><TeamDetailPage /></PrivateRoute>} />
         <Route path="/teams/create" element={<PrivateRoute><TeamCreatePage /></PrivateRoute>} />
         <Route path="/mypage" element={<PrivateRoute><MyPage /></PrivateRoute>} />
         <Route path="/login" element={<LoginPage />} />

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -39,6 +39,7 @@ function MyPage() {
   const [error, setError] = useState(null)
   const [nicknameError, setNicknameError] = useState(null)
   const [isCheckingNickname, setIsCheckingNickname] = useState(false)
+  const [isNicknameChecked, setIsNicknameChecked] = useState(false)
   const [formData, setFormData] = useState({
     nickname: '',
     phone: '',
@@ -75,27 +76,34 @@ function MyPage() {
     }
     setIsEditing(true)
     setError(null)
+    setNicknameError(null)
+    setIsNicknameChecked(false)
   }
 
   const handleCancel = () => {
     setIsEditing(false)
     setError(null)
+    setNicknameError(null)
+    setIsNicknameChecked(false)
   }
 
   const checkNickname = async (nickname) => {
     if (!nickname || nickname.trim() === '') {
       setNicknameError(null)
+      setIsNicknameChecked(false)
       return true
     }
 
     // 현재 닉네임과 같으면 검사하지 않음
     if (nickname === user?.nickname) {
       setNicknameError(null)
+      setIsNicknameChecked(false)
       return true
     }
 
     setIsCheckingNickname(true)
     setNicknameError(null)
+    setIsNicknameChecked(false)
 
     try {
       const res = await api.get(`/v1/users/check`, {
@@ -105,14 +113,18 @@ function MyPage() {
       
       if (!isAvailable) {
         setNicknameError('이미 사용 중인 닉네임입니다.')
+        setIsNicknameChecked(true)
         return false
       } else {
         setNicknameError(null)
+        setIsNicknameChecked(true)
         return true
       }
     } catch (e) {
-      setNicknameError(null)
-      return true
+      const errorMessage = e.response?.data?.message || e.message || '닉네임 중복 검사 중 오류가 발생했습니다.'
+      setNicknameError(errorMessage)
+      setIsNicknameChecked(true)
+      return false
     } finally {
       setIsCheckingNickname(false)
     }
@@ -127,6 +139,7 @@ function MyPage() {
     // 빈 값이거나 현재 닉네임과 같으면 검사하지 않음
     if (!nickname || nickname.trim() === '' || nickname === user?.nickname) {
       setNicknameError(null)
+      setIsNicknameChecked(false)
       return
     }
 
@@ -141,9 +154,10 @@ function MyPage() {
     const { name, value } = e.target
     setFormData(prev => ({ ...prev, [name]: value }))
     
-    // 닉네임 변경 시 에러 초기화 (실제 검사는 useEffect에서)
+    // 닉네임 변경 시 에러 및 검사 완료 상태 초기화 (실제 검사는 useEffect에서)
     if (name === 'nickname') {
       setNicknameError(null)
+      setIsNicknameChecked(false)
     }
   }
 
@@ -151,6 +165,18 @@ function MyPage() {
     e.preventDefault()
     setIsSaving(true)
     setError(null)
+
+    // 변경사항이 있는지 확인
+    const hasChanges = 
+      formData.nickname.trim() !== (user?.nickname || '') ||
+      formData.position.trim() !== (user?.position || '') ||
+      formData.phone.trim() !== (user?.phone || '')
+
+    if (!hasChanges) {
+      setIsEditing(false)
+      setIsSaving(false)
+      return
+    }
 
     // 닉네임이 변경되었고, 현재 중복 검사 결과가 없으면 다시 검사
     if (formData.nickname && formData.nickname !== user?.nickname) {
@@ -172,6 +198,8 @@ function MyPage() {
 
       await api.patch('/v1/users', payload)
       setIsEditing(false)
+      setNicknameError(null)
+      setIsNicknameChecked(false)
       // 사용자 정보 다시 조회
       await refetch()
     } catch (e) {
@@ -343,7 +371,7 @@ function MyPage() {
                 {nicknameError && (
                   <p className="text-red-600 text-xs mt-1">{nicknameError}</p>
                 )}
-                {formData.nickname && !nicknameError && !isCheckingNickname && formData.nickname !== user?.nickname && (
+                {formData.nickname && !nicknameError && !isCheckingNickname && isNicknameChecked && formData.nickname !== user?.nickname && (
                   <p className="text-green-600 text-xs mt-1">사용 가능한 닉네임입니다.</p>
                 )}
               </label>

--- a/src/pages/TeamCreate.jsx
+++ b/src/pages/TeamCreate.jsx
@@ -1,17 +1,21 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { api } from '../shared/api/client'
 import Button from '../shared/ui/Button.jsx'
 
 function TeamCreatePage() {
   const navigate = useNavigate()
+  const fileInputRef = useRef(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [imagePreview, setImagePreview] = useState(null)
   const [formData, setFormData] = useState({
+    image: null,
     name: '',
+    area: '',
     description: '',
-    region: '',
-    activityDay: '',
+    contactType: 'KAKAO',
+    contact: '',
     level: '',
   })
 
@@ -20,14 +24,86 @@ function TeamCreatePage() {
     setFormData(prev => ({ ...prev, [name]: value }))
   }
 
+  const handleImageChange = (e) => {
+    const file = e.target.files[0]
+    if (file) {
+      setFormData(prev => ({ ...prev, image: file }))
+      // 미리보기 URL 생성
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        setImagePreview(reader.result)
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  const handleImageRemove = (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setFormData(prev => ({ ...prev, image: null }))
+    setImagePreview(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }
+
   const onSubmit = async (e) => {
     e.preventDefault()
     setIsLoading(true)
     setError(null)
 
     try {
-      const res = await api.post('/v1/teams', formData)
+      let imageUrl = null
+
+      // 이미지가 있으면 S3에 업로드
+      if (formData.image) {
+        // 1. 서명된 URL 받기
+        const presignRes = await api.post('/v1/aws/s3/presign-upload', {
+          fileName: formData.image.name,
+          contentType: formData.image.type,
+        })
+
+        const presignData = presignRes.data?.data
+        if (!presignData || !presignData.url) {
+          throw new Error('서명된 URL을 받아오는데 실패했습니다.')
+        }
+
+        // 2. 서명된 URL로 이미지 업로드 (PUT 요청)
+        const uploadRes = await fetch(presignData.url, {
+          method: 'PUT',
+          body: formData.image,
+          headers: {
+            'Content-Type': formData.image.type,
+          },
+        })
+
+        if (!uploadRes.ok) {
+          throw new Error('이미지 업로드에 실패했습니다.')
+        }
+
+        // 3. 업로드된 이미지의 base URL 추출 (query string 제거)
+        const urlObj = new URL(presignData.url)
+        imageUrl = `${urlObj.protocol}//${urlObj.host}${urlObj.pathname}`
+      }
+
+      // 4. 팀 생성 API 호출 (이미지 URL만 전송)
+      const payload = {
+        name: formData.name,
+        area: formData.area,
+        description: formData.description || '',
+        contactType: formData.contactType,
+        contact: formData.contact,
+        level: formData.level,
+      }
+      
+      if (imageUrl) {
+        payload.imgUrl = imageUrl
+      }
+
+      const res = await api.post('/v1/teams', payload)
+      
       if (res.data) {
+        alert('팀이 성공적으로 생성되었습니다.')
         navigate('/teams', { replace: true })
       }
     } catch (e) {
@@ -48,8 +124,51 @@ function TeamCreatePage() {
 
         <div className="rounded-2xl border border-gray-100 bg-white/80 shadow-card p-6">
           <form onSubmit={onSubmit} className="grid gap-4">
+            {/* 1. 팀 이미지 */}
             <label className="grid gap-1">
-              <span className="text-sm text-mute">팀명 <span className="text-red-500">*</span></span>
+              <span className="text-sm text-mute">팀 이미지</span>
+              <div className="space-y-2">
+                <div className="relative border border-gray-200 rounded-lg overflow-hidden bg-gray-50 h-64 flex items-center justify-center">
+                  {imagePreview ? (
+                    <>
+                      <img 
+                        src={imagePreview} 
+                        alt="팀 이미지 미리보기" 
+                        className="w-full h-full object-cover"
+                      />
+                      <button
+                        type="button"
+                        onClick={handleImageRemove}
+                        onMouseDown={(e) => e.preventDefault()}
+                        className="absolute top-2 right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-8 h-8 flex items-center justify-center text-sm transition-colors z-10"
+                      >
+                        ×
+                      </button>
+                    </>
+                  ) : (
+                    <span className="text-mute text-sm">이미지를 선택해주세요</span>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="w-full text-sm py-2 px-3 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors text-mute"
+                >
+                  {imagePreview ? '이미지 변경' : '이미지 선택'}
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleImageChange}
+                  className="hidden"
+                />
+              </div>
+            </label>
+
+            {/* 2. 팀 이름 */}
+            <label className="grid gap-1">
+              <span className="text-sm text-mute">팀 이름 <span className="text-red-500">*</span></span>
               <input
                 type="text"
                 name="name"
@@ -61,8 +180,24 @@ function TeamCreatePage() {
               />
             </label>
 
+            {/* 3. 팀 활동 지역 */}
             <label className="grid gap-1">
-              <span className="text-sm text-mute">팀 소개</span>
+              <span className="text-sm text-mute">팀 활동 지역 <span className="text-red-500">*</span></span>
+              <input
+                type="text"
+                name="area"
+                placeholder="서울-노원구"
+                value={formData.area}
+                onChange={handleChange}
+                required
+                className="border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              />
+              <p className="text-xs text-mute mt-0.5">시/도-구/군 형식으로 입력해주세요. (예: 서울-노원구, 경기-성남시)</p>
+            </label>
+
+            {/* 4. 팀 설명 */}
+            <label className="grid gap-1">
+              <span className="text-sm text-mute">팀 설명</span>
               <textarea
                 name="description"
                 placeholder="팀 소개를 입력해주세요."
@@ -73,53 +208,59 @@ function TeamCreatePage() {
               />
             </label>
 
+            {/* 5. 팀 레벨 */}
             <label className="grid gap-1">
-              <span className="text-sm text-mute">활동 지역 <span className="text-red-500">*</span></span>
-              <input
-                type="text"
-                name="region"
-                placeholder="서울, 경기, 부산 등"
-                value={formData.region}
-                onChange={handleChange}
-                required
-                className="border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-200"
-              />
-            </label>
-
-            <label className="grid gap-1">
-              <span className="text-sm text-mute">주 활동 요일</span>
-              <select
-                name="activityDay"
-                value={formData.activityDay}
-                onChange={handleChange}
-                className="border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-200"
-              >
-                <option value="">선택해주세요</option>
-                <option value="MONDAY">월요일</option>
-                <option value="TUESDAY">화요일</option>
-                <option value="WEDNESDAY">수요일</option>
-                <option value="THURSDAY">목요일</option>
-                <option value="FRIDAY">금요일</option>
-                <option value="SATURDAY">토요일</option>
-                <option value="SUNDAY">일요일</option>
-              </select>
-            </label>
-
-            <label className="grid gap-1">
-              <span className="text-sm text-mute">팀 수준</span>
+              <span className="text-sm text-mute">팀 레벨 <span className="text-red-500">*</span></span>
               <select
                 name="level"
                 value={formData.level}
                 onChange={handleChange}
+                required
                 className="border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-200"
               >
                 <option value="">선택해주세요</option>
-                <option value="BEGINNER">초급</option>
-                <option value="INTERMEDIATE">중급</option>
-                <option value="ADVANCED">고급</option>
-                <option value="PROFESSIONAL">전문</option>
+                <option value="하하">하하</option>
+                <option value="중하">중하</option>
+                <option value="중">중</option>
+                <option value="중상">중상</option>
+                <option value="상">상</option>
               </select>
             </label>
+
+            {/* 6. 연락수단 */}
+            <div className="grid gap-2">
+              <label className="grid gap-1">
+                <span className="text-sm text-mute">연락수단 타입 <span className="text-red-500">*</span></span>
+                <select
+                  name="contactType"
+                  value={formData.contactType}
+                  onChange={handleChange}
+                  className="border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                >
+                  <option value="KAKAO">카카오톡 ID</option>
+                  <option value="PHONE">전화번호</option>
+                  <option value="EMAIL">이메일</option>
+                </select>
+              </label>
+              <label className="grid gap-1">
+                <span className="text-sm text-mute">연락처 정보 <span className="text-red-500">*</span></span>
+                <input
+                  type="text"
+                  name="contact"
+                  placeholder={
+                    formData.contactType === 'KAKAO' 
+                      ? '카카오톡 ID를 입력해주세요'
+                      : formData.contactType === 'PHONE'
+                      ? '전화번호를 입력해주세요 (예: 010-1234-5678)'
+                      : '이메일을 입력해주세요'
+                  }
+                  value={formData.contact}
+                  onChange={handleChange}
+                  required
+                  className="border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                />
+              </label>
+            </div>
 
             {error && (
               <p className="text-red-600 text-sm">{error}</p>

--- a/src/pages/TeamDetail.jsx
+++ b/src/pages/TeamDetail.jsx
@@ -1,0 +1,155 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { api } from '../shared/api/client'
+import Button from '../shared/ui/Button.jsx'
+
+function TeamDetailPage() {
+  const { teamId } = useParams()
+  const navigate = useNavigate()
+  const [team, setTeam] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [isApplying, setIsApplying] = useState(false)
+  const [applyMessage, setApplyMessage] = useState('')
+
+  useEffect(() => {
+    fetchTeamDetail()
+  }, [teamId])
+
+  const fetchTeamDetail = async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+      const res = await api.get(`/v1/teams/${teamId}`)
+      setTeam(res.data?.data)
+    } catch (e) {
+      const errorMessage = e.response?.data?.message || e.message || '팀 정보를 불러오는데 실패했습니다.'
+      setError(errorMessage)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleApply = async () => {
+    if (!applyMessage.trim()) {
+      alert('가입 신청 메시지를 입력해주세요.')
+      return
+    }
+
+    try {
+      setIsApplying(true)
+      await api.post(`/v1/teams/${teamId}/join`, {
+        message: applyMessage
+      })
+      alert('가입 신청이 완료되었습니다.')
+      navigate('/teams', { replace: true })
+    } catch (e) {
+      const errorMessage = e.response?.data?.message || e.message || '가입 신청에 실패했습니다.'
+      alert(errorMessage)
+    } finally {
+      setIsApplying(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <section className="py-10 sm:py-14">
+        <div className="max-w-2xl mx-auto">
+          <div className="text-center py-10">
+            <p className="text-mute">로딩 중...</p>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  if (error || !team) {
+    return (
+      <section className="py-10 sm:py-14">
+        <div className="max-w-2xl mx-auto">
+          <div className="text-center py-10">
+            <p className="text-red-600">{error || '팀 정보를 찾을 수 없습니다.'}</p>
+            <Button
+              variant="ghost"
+              onClick={() => navigate('/teams', { replace: true })}
+              className="mt-4"
+            >
+              목록으로 돌아가기
+            </Button>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="py-10 sm:py-14">
+      <div className="max-w-2xl mx-auto">
+        <Button
+          variant="ghost"
+          onClick={() => navigate('/teams', { replace: true })}
+          className="mb-4"
+        >
+          ← 목록으로
+        </Button>
+
+        <div className="rounded-2xl border border-gray-100 bg-white/80 shadow-card p-6">
+          {team.img && (
+            <div className="w-full h-64 mb-6 rounded-lg overflow-hidden bg-gray-100">
+              <img
+                src={team.img}
+                alt={team.name}
+                className="w-full h-full object-cover"
+              />
+            </div>
+          )}
+
+          <div className="grid gap-4">
+            <div>
+              <h2 className="text-2xl font-semibold text-ink mb-2">{team.name}</h2>
+              <div className="text-mute text-sm">{team.area}</div>
+            </div>
+
+            {team.description && (
+              <div>
+                <h3 className="text-sm font-medium text-ink mb-2">팀 소개</h3>
+                <p className="text-mute text-sm whitespace-pre-wrap">{team.description}</p>
+              </div>
+            )}
+
+            <div>
+              <h3 className="text-sm font-medium text-ink mb-2">팀 정보</h3>
+              <div className="text-mute text-sm mb-1">멤버 {team.memberCount}명</div>
+              {team.level && (
+                <div className="text-mute text-sm">레벨: {team.level}</div>
+              )}
+            </div>
+
+            <div className="pt-4 border-t border-gray-100">
+              <label className="grid gap-1 mb-4">
+                <span className="text-sm text-mute">가입 신청 메시지</span>
+                <textarea
+                  value={applyMessage}
+                  onChange={(e) => setApplyMessage(e.target.value)}
+                  rows={3}
+                  className="border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-200 resize-none"
+                  placeholder="가입 신청 메시지를 입력하세요"
+                />
+              </label>
+              <Button
+                onClick={handleApply}
+                disabled={isApplying}
+                className="w-full"
+              >
+                {isApplying ? '신청 중...' : '가입 신청하기'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default TeamDetailPage
+

--- a/src/pages/Teams.jsx
+++ b/src/pages/Teams.jsx
@@ -1,26 +1,144 @@
-import { Link } from 'react-router-dom'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { api } from '../shared/api/client'
 import Button from '../shared/ui/Button.jsx'
 
 function TeamsPage() {
+  const navigate = useNavigate()
+  const [teams, setTeams] = useState([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState(null)
+  const [page, setPage] = useState(0)
+  const [isLastPage, setIsLastPage] = useState(false)
+  const observerTarget = useRef(null)
+
+  useEffect(() => {
+    fetchTeams(0, true)
+  }, [])
+
+  const fetchTeams = async (pageNum = 0, isInitial = false) => {
+    try {
+      if (isInitial) {
+        setIsLoading(true)
+      } else {
+        setIsLoadingMore(true)
+      }
+      setError(null)
+      const res = await api.get('/v1/teams', {
+        params: {
+          page: pageNum,
+          size: 20
+        }
+      })
+      const responseData = res.data?.data
+      const teamsData = responseData?.content || []
+      const last = responseData?.last ?? false
+
+      if (isInitial) {
+        setTeams(teamsData)
+      } else {
+        setTeams(prev => [...prev, ...teamsData])
+      }
+      setIsLastPage(last)
+      setPage(pageNum)
+    } catch (e) {
+      const errorMessage = e.response?.data?.message || e.message || '팀 목록을 불러오는데 실패했습니다.'
+      setError(errorMessage)
+    } finally {
+      setIsLoading(false)
+      setIsLoadingMore(false)
+    }
+  }
+
+  const loadMore = useCallback(() => {
+    if (!isLoadingMore && !isLastPage) {
+      fetchTeams(page + 1, false)
+    }
+  }, [page, isLoadingMore, isLastPage])
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !isLoadingMore && !isLastPage) {
+          loadMore()
+        }
+      },
+      { threshold: 0.1 }
+    )
+
+    if (observerTarget.current) {
+      observer.observe(observerTarget.current)
+    }
+
+    return () => {
+      if (observerTarget.current) {
+        observer.unobserve(observerTarget.current)
+      }
+    }
+  }, [loadMore, isLoadingMore, isLastPage])
+
   return (
     <section className="py-10 sm:py-14">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <div className="grid gap-2">
           <h2 className="text-3xl font-semibold text-ink">팀 찾기</h2>
-          <p className="text-mute">랭크, 활동지역, 요일, 매너지수 기준으로 팀을 찾아보세요.</p>
+          <p className="text-mute">다양한 팀을 찾아보고 가입 신청을 해보세요.</p>
         </div>
         <Link to="/teams/create" className="w-full sm:w-auto">
           <Button className="w-full sm:w-auto">팀 생성하기</Button>
         </Link>
       </div>
-      <div className="mt-6 grid sm:grid-cols-3 gap-4">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="rounded-xl border border-gray-100 p-4 bg-white/70 shadow-card">
-            <div className="text-ink font-medium">판교 FC</div>
-            <div className="text-mute text-sm">판교 · 토/일 오전 · 매너지수 상</div>
+
+      {isLoading ? (
+        <div className="text-center py-10">
+          <p className="text-mute">로딩 중...</p>
+        </div>
+      ) : error ? (
+        <div className="text-center py-10">
+          <p className="text-red-600">{error}</p>
+        </div>
+      ) : teams.length === 0 ? (
+        <div className="text-center py-10">
+          <p className="text-mute">등록된 팀이 없습니다.</p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-6 grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {teams.map((team) => (
+              <div
+                key={team.id}
+                onClick={() => navigate(`/teams/${team.id}`)}
+                className="rounded-xl border border-gray-100 p-4 bg-white/70 shadow-card cursor-pointer hover:shadow-lg transition-shadow"
+              >
+                {team.img && (
+                  <div className="w-full h-40 mb-3 rounded-lg overflow-hidden bg-gray-100">
+                    <img
+                      src={team.img}
+                      alt={team.name}
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
+                )}
+                <div className="text-ink font-medium text-lg mb-1">{team.name}</div>
+                <div className="text-mute text-sm mb-2">{team.area}</div>
+                {team.description && (
+                  <div className="text-mute text-sm mb-2 line-clamp-2">{team.description}</div>
+                )}
+                <div className="text-mute text-xs">멤버 {team.memberCount}명</div>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+          <div ref={observerTarget} className="h-10 flex items-center justify-center">
+            {isLoadingMore && (
+              <p className="text-mute text-sm">더 불러오는 중...</p>
+            )}
+            {isLastPage && teams.length > 0 && (
+              <p className="text-mute text-sm">모든 팀을 불러왔습니다.</p>
+            )}
+          </div>
+        </>
+      )}
     </section>
   )
 }

--- a/src/shared/api/client.js
+++ b/src/shared/api/client.js
@@ -1,10 +1,24 @@
 import axios from "axios";
-import { getAuthToken } from "../store/authStore";
+import { getAuthToken, setAuthToken } from "../store/authStore";
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL ? `${import.meta.env.VITE_API_BASE_URL}/api` : '/api',
   withCredentials: true,
 })
+
+let isRefreshing = false
+let failedQueue = []
+
+const processQueue = (error, token = null) => {
+  failedQueue.forEach(prom => {
+    if (error) {
+      prom.reject(error)
+    } else {
+      prom.resolve(token)
+    }
+  })
+  failedQueue = []
+}
 
 api.interceptors.request.use((config) => {
   const token = getAuthToken()
@@ -24,3 +38,63 @@ api.interceptors.request.use((config) => {
   }
   return config
 })
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
+
+    // 401 에러이고, 재시도하지 않은 요청인 경우
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        // 이미 토큰 갱신 중이면 대기
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject })
+        })
+          .then(token => {
+            originalRequest.headers.Authorization = `Bearer ${token}`
+            return api(originalRequest)
+          })
+          .catch(err => {
+            return Promise.reject(err)
+          })
+      }
+
+      originalRequest._retry = true
+      isRefreshing = true
+
+      try {
+        // 토큰 재발급 요청 (인증 없이 호출)
+        const baseURL = api.defaults.baseURL || (import.meta.env.VITE_API_BASE_URL ? `${import.meta.env.VITE_API_BASE_URL}/api` : '/api')
+        const res = await axios.post(
+          `${baseURL}/v1/auth/reissue`,
+          {},
+          { withCredentials: true }
+        )
+
+        const newAccessToken = res.data?.data?.accessToken
+        if (newAccessToken) {
+          setAuthToken(newAccessToken)
+          processQueue(null, newAccessToken)
+          
+          // 원래 요청 재시도
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`
+          return api(originalRequest)
+        } else {
+          throw new Error('토큰 재발급에 실패했습니다.')
+        }
+      } catch (refreshError) {
+        processQueue(refreshError, null)
+        // 재발급 실패 시 로그아웃 처리
+        const { useAuthStore } = await import('../store/authStore')
+        useAuthStore.getState().clearAuth()
+        window.location.href = '/login'
+        return Promise.reject(refreshError)
+      } finally {
+        isRefreshing = false
+      }
+    }
+
+    return Promise.reject(error)
+  }
+)

--- a/src/shared/hook/useAuth.js
+++ b/src/shared/hook/useAuth.js
@@ -42,9 +42,18 @@ export function useAuth() {
   }, [])
 
   const isAuthenticated = Boolean(getAuthToken())
-  const logout = useCallback(() => {
-    clearAuth()
-    clearUserCache()
+  const logout = useCallback(async () => {
+    try {
+      // refreshToken 삭제를 위한 로그아웃 API 호출
+      await api.post('/v1/auth/logout')
+    } catch (e) {
+      // 로그아웃 API 실패해도 클라이언트에서는 로그아웃 처리
+      console.error('로그아웃 API 호출 실패:', e)
+    } finally {
+      // accessToken 삭제 및 사용자 캐시 클리어
+      clearAuth()
+      clearUserCache()
+    }
   }, [clearAuth])
 
   const signupWithEmail = useCallback(async ({ userName, email, password, position, phone }) => {


### PR DESCRIPTION
## [Feat] User 및 Team 페이지 기능 구현

### 1. 마이페이지 개선
- ✅ 닉네임 중복검사 에러 처리 개선 (에러 발생 시 사용 불가 처리)
- ✅ 닉네임 중복검사 완료 후에만 "사용 가능한 닉네임입니다" 메시지 표시
- ✅ 변경사항이 없을 때 불필요한 API 요청 방지

### 2. 팀 관련 기능 구현
- ✅ 팀 리스트 조회 API 연동 및 무한스크롤 구현
- ✅ 팀 상세 조회 페이지 구현
- ✅ 팀 가입 신청 기능 구현
- ✅ 팀 생성 페이지 이미지 업로드 (S3 presigned URL 방식)
- ✅ 팀 레벨 필드 추가 (하하, 중하, 중, 중상, 상)

### 3. 인증 기능 개선
- ✅ refreshToken 기반 토큰 재발급 로직 구현
- ✅ 401 에러 발생 시 자동 토큰 갱신 및 요청 재시도
- ✅ 로그아웃 시 refreshToken 삭제 API 호출

### 4. API 스펙 반영
- ✅ Swagger 문서 기반 API 엔드포인트 수정
  - 팀 가입 신청: `/api/v1/teams/{teamId}/join`
  - 팀 생성 필수 필드: `level` 추가

## 📁 변경된 파일

- `src/App.jsx` - 팀 상세 페이지 라우트 추가
- `src/pages/MyPage.jsx` - 닉네임 중복검사 및 변경사항 체크 로직 개선
- `src/pages/TeamCreate.jsx` - S3 이미지 업로드, 팀 레벨 필드 추가
- `src/pages/TeamDetail.jsx` - 팀 상세 조회 및 가입 신청 기능 (신규)
- `src/pages/Teams.jsx` - 팀 리스트 조회 API 연동, 무한스크롤 구현
- `src/shared/api/client.js` - 401 에러 처리 및 토큰 재발급 로직 추가
- `src/shared/hook/useAuth.js` - 로그아웃 시 refreshToken 삭제 API 호출

## 🔧 기술적 개선사항

- **무한스크롤**: IntersectionObserver를 활용한 효율적인 페이지네이션 처리
- **토큰 관리**: 동시 요청 시 중복 토큰 재발급 방지 및 큐 처리
- **이미지 업로드**: S3 presigned URL을 통한 직접 업로드 방식 적용

